### PR TITLE
Must support encryption at rest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,15 @@
 # Changelog
 
-## [0.4.2 UNRELEASED]
-
-### Added
-
-- Added support for root secret key rollover when using Vault for secret keeping #115
-
-### Changed
-
-## [0.4.1]
+## [0.4.2]
 
 ### Added
 - Added Native Vault KMS support using Vault transit encryption #113
   - In this version we are using the deprecated native vault integration.
   - EOL for this feature is October 2021
   - Switch to [MinIO KES](https://github.com/minio/kes/wiki/Hashicorp-Vault-Keystore) before then
+- Added support for root secret key rollover when using Vault for secret keeping #115
+
+## [0.4.1]
 
 ### Changed
 - Now uses the mc_container_image instead of hardcoded image [#100](https://github.com/fredrikhgrelland/terraform-nomad-minio/issues/100)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [0.4.1]
 
+### Added
+- Added Native Vault KMS support using Vault transit encryption #113
+  - In this version we are using the deprecated native vault integration.
+  - EOL for this feature is October 2021
+  - Switch to [MinIO KES](https://github.com/minio/kes/wiki/Hashicorp-Vault-Keystore) before then
+
 ### Changed
 - Now uses the mc_container_image instead of hardcoded image [#100](https://github.com/fredrikhgrelland/terraform-nomad-minio/issues/100)
 - Image is configurable #107

--- a/README.md
+++ b/README.md
@@ -247,8 +247,8 @@ resource "vault_generic_secret" "kms_approle" {
 ```
 
 ``use_vault_kms``
-This is false by default, but can be turned on if you want to use vaults integrated transit encryption to manage your keys. 
-The keys will then be store in ``secrets/kms`` folder inside of vault. You can change the path where the keys 
+This is false by default, but can be turned on if you want to use vaults integrated transit encryption to manage your keys.
+The keys will then be store in ``secrets/kms`` folder inside of vault. You can change the path where the keys
 are stored by changing this variable ``vault_kms_approle_kv`` but that is only relevant if you `use_vault_kms = true`.
 
 ## Volumes

--- a/README.md
+++ b/README.md
@@ -254,8 +254,8 @@ resource "vault_generic_secret" "kms_approle" {
 
 module minio {
    # ... other configuration
-   
-  kms_variables                   = {
+
+   kms_variables                   = {
                                      use_vault_kms = true,
                                      vault_address = "http://10.0.2.15:8200",
                                      vault_kms_approle_kv = vault_generic_secret.kms_approle.path,

--- a/README.md
+++ b/README.md
@@ -221,7 +221,16 @@ module "minio" {
                   }
 }
 ```
-
+### Key Management Secrets (KMS)
+The Key Management secrets engine provides a consistent workflow for distribution and lifecycle management of cryptographic keys in various key management service (KMS) providers.
+ ```hcl
+ variable "use_vault_kms" {
+   type = bool
+   default = false
+   description = "Use vault transit encryption engine as KMS for transparent encryption (auto-encrypt)"
+}
+ ```
+This is false by default, but can be turned on if you want to use vaults integrated transit encryption to manage your keys. The keys will then be store in ``secrets/kms`` folder inside of vault. You can change the path where the keys are stored by changing this variable ``vault_kms_approle_kv`` but that is only relevant if you `use_vault_kms = true`.
 ## Volumes
 We are using [host volume](https://www.nomadproject.io/docs/job-specification/volume) to store Minio data.
 Minio data will now be available in the `persistence/minio` folder.

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ module "minio" {
 }
 ```
 ### Key Management Secrets (KMS)
-The Key Management secrets engine provides a consistent workflow for distribution and lifecycle management of 
+The Key Management secrets engine provides a consistent workflow for distribution and lifecycle management of
 cryptographic keys in various key management service (KMS) providers.
  ```hcl
 resource "vault_generic_secret" "kms_transit_key" {

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ make up
 Minio example instance has:
 - [buckets ["one", "two"]](example/minio_standalone/main.tf)
 - [different type of files uploaded to bucket `one/`](./dev/ansible/04_upload_files.yml)
+- Transparent encryption using Vault transit engine as KMS
 
 ### Verifying setup
 You can verify that Minio ran successful by checking the Minio UI.
@@ -106,6 +107,7 @@ module "minio" {
   container_environment_variables = ["SOME_VAR_N1=some-value"]
   use_host_volume                 = true
   use_canary                      = true
+  use_vault_kms                   = false
 
   # minio client
   mc_service_name                 = "mc"
@@ -144,7 +146,10 @@ module "minio" {
 | vault_secret.vault_kv_field_secret_key | Secret key name in Vault kv path | string | "secret_key" |
 | minio\_upstreams | List up connect upstreams | list(object) | [] | no |
 | mc\_extra\_commands | Extra commands to run in MC container after creating buckets | list(string) | [] | no |
-
+| use_vault_kms | Use vault transit encryption engine as KMS for transparent encryption (auto-encrypt)| bool | false | no |
+| vault_address | Address to vault service. Only relevant when Vault KMS is used. | string | "" | no |
+| vault_kms_approle_kv | Path to key in vault where ApproleID and SecretID is stored. Only relevant when Vault KMS is used. | string | "" | no |
+| vault_kms_key_name | Name of key in vault transit engine. Only relevant when Vault KMS is used. | string | "" | no |
 
 ## Outputs
 | Name | Description | Type |

--- a/Vagrantfile.default
+++ b/Vagrantfile.default
@@ -1,6 +1,6 @@
 Vagrant.configure("2") do |config|
     config.vm.box = "fredrikhgrelland/hashistack"
-    config.vm.box_version = ">= 0.7, < 0.8"
+    config.vm.box_version = ">= 0.10, < 0.11"
     config.vm.boot_timeout = 600
     config.vm.provider "virtualbox" do |vb|
         vb.linked_clone = true

--- a/conf/nomad/minio.hcl
+++ b/conf/nomad/minio.hcl
@@ -137,6 +137,24 @@ MINIO_SECRET_KEY="${secret_key}"
 ${ envs }
 EOF
       }
+%{ if use_vault_kms }
+template {
+data = <<EOH
+          {{ with secret "${vault_kms_approle_kv}" }}
+          MINIO_KMS_VAULT_APPROLE_ID="{{ .Data.data.approle_id }}"
+          MINIO_KMS_VAULT_APPROLE_SECRET="{{ .Data.data.secret_id }}"
+          {{end}}
+          MINIO_KMS_VAULT_ENDPOINT=${vault_address}
+          MINIO_KMS_VAULT_KEY_NAME=${vault_kms_key_name}
+          MINIO_KMS_VAULT_AUTH_TYPE=approle
+          MINIO_KMS_AUTO_ENCRYPTION=on
+          MINIO_KMS_VAULT_DEPRECATION=off
+          EOH
+
+        destination = "secrets/kms"
+        env         = true
+    }
+%{endif}
       resources {
         cpu     = ${cpu}
         memory  = ${memory}

--- a/conf/nomad/minio.hcl
+++ b/conf/nomad/minio.hcl
@@ -125,22 +125,23 @@ job "${service_name}" {
         change_mode = "noop"
         env         = true
         data        = <<EOF
-%{ if use_vault_provider }
-{{ with secret "${vault_kv_path}" }}
-MINIO_ACCESS_KEY="{{ .Data.data.${vault_kv_field_access_key} }}"
-MINIO_SECRET_KEY="{{ .Data.data.${vault_kv_field_secret_key} }}"
-{{ end }}
-%{ else }
-MINIO_ACCESS_KEY="${access_key}"
-MINIO_SECRET_KEY="${secret_key}"
-%{ endif }
+
+  %{ if use_vault_provider }
+    {{ with secret "${vault_kv_path}" }}
+      MINIO_ACCESS_KEY="{{ .Data.data.${vault_kv_field_access_key} }}"
+      MINIO_SECRET_KEY="{{ .Data.data.${vault_kv_field_secret_key} }}"
+    {{ end }}
+  %{ else }
+    MINIO_ACCESS_KEY="${access_key}"
+    MINIO_SECRET_KEY="${secret_key}"
+  %{ endif }
 ${ envs }
 EOF
       }
-%{ if use_vault_kms }
-template {
-data = <<EOH
-          {{ with secret "${vault_kms_approle_kv}" }}
+  %{ if use_vault_kms }
+    template {
+      data = <<EOH
+        {{ with secret "${vault_kms_approle_kv}" }}
           MINIO_KMS_VAULT_APPROLE_ID="{{ .Data.data.approle_id }}"
           MINIO_KMS_VAULT_APPROLE_SECRET="{{ .Data.data.secret_id }}"
           {{end}}
@@ -149,7 +150,7 @@ data = <<EOH
           MINIO_KMS_VAULT_AUTH_TYPE=approle
           MINIO_KMS_AUTO_ENCRYPTION=on
           MINIO_KMS_VAULT_DEPRECATION=off
-          EOH
+        EOH
 
         destination = "secrets/kms"
         env         = true

--- a/dev/vagrant/bootstrap/vault/post/01-create_vault_policy_to_read_secrets.yml
+++ b/dev/vagrant/bootstrap/vault/post/01-create_vault_policy_to_read_secrets.yml
@@ -4,6 +4,9 @@
     path "secret/data/minio" {
     capabilities = ["read"]
     }
+    path "secret/data/kms" {
+    capabilities = ["read"]
+    }
     EOF
   register: cmd_op
   environment:

--- a/dev/vagrant/bootstrap/vault/post/020-setup-transit-secret-engine.yml
+++ b/dev/vagrant/bootstrap/vault/post/020-setup-transit-secret-engine.yml
@@ -1,0 +1,70 @@
+# https://docs.min.io/docs/minio-vault-legacy.html
+- name: Enable AppRole auth
+  shell: vault auth enable approle
+  register: app_role_enable
+  environment:
+    VAULT_TOKEN: "{{ lookup('env', 'vault_master_token') }}"
+  retries: 5
+  delay: 5
+
+- name: Enable Transit secret engine
+  shell: vault secrets enable transit
+  register: vault_transit_enable
+  environment:
+    VAULT_TOKEN: "{{ lookup('env', 'vault_master_token') }}"
+  retries: 5
+  delay: 5
+
+- name: Define a policy for AppRole to access transit path
+  shell: |
+    vault policy write minio-policy - << EOF
+    path "transit/datakey/plaintext/my-minio-key" {
+      capabilities = [ "read", "update"]
+    }
+    path "transit/decrypt/my-minio-key" {
+      capabilities = [ "read", "update"]
+    }
+    path "transit/rewrap/my-minio-key" {
+      capabilities = ["update"]
+    }
+    EOF
+  register: define_policy_try1
+  environment:
+    VAULT_TOKEN: "{{ lookup('env', 'vault_master_token') }}"
+  until: define_policy_try1.rc == 0
+  retries: 5
+  delay: 15
+
+- name: Define appRole - minio-role with period
+  shell: vault write auth/approle/role/minio-role token_num_uses=0  secret_id_num_uses=0  period=5m
+  register: write_approle_try1
+  environment:
+    VAULT_TOKEN: "{{ lookup('env', 'vault_master_token') }}"
+  until: write_approle_try1.rc == 0
+  retries: 5
+  delay: 15
+
+- name: Apply role to policy
+  shell: vault write auth/approle/role/minio-role policies=minio-policy
+  register: write_approle_try2
+  environment:
+    VAULT_TOKEN: "{{ lookup('env', 'vault_master_token') }}"
+  until: write_approle_try1.rc == 0
+  retries: 5
+  delay: 15
+
+- name: Get app-role to policy
+  shell: vault read auth/approle/role/minio-role/role-id -format=json | jq -r '.data.role_id'  # get Approle ID
+  register: role_id
+  environment:
+    VAULT_TOKEN: "{{ lookup('env', 'vault_master_token') }}"
+  retries: 5
+  delay: 5
+
+- name: Generate secret_id and accessor for minio-role
+  shell: vault write -f auth/approle/role/minio-role/secret-id -format=json | jq -r '.data.role_id'  # get Approle ID
+  register: role_secrets
+  environment:
+    VAULT_TOKEN: "{{ lookup('env', 'vault_master_token') }}"
+  retries: 5
+  delay: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: 3
+services:
+  minio:
+    image: minio/minio
+    environment:
+      - MINIO_KMS_VAULT_APPROLE_ID=
+      - MINIO_KMS_VAULT_APPROLE_SECRET=
+      - MINIO_KMS_VAULT_ENDPOINT=http://127.0.0.1:8200
+      - MINIO_KMS_VAULT_KEY_NAME=my-minio-key
+      - MINIO_KMS_VAULT_AUTH_TYPE=approle
+    network_mode: host

--- a/example/minio_standalone/main.tf
+++ b/example/minio_standalone/main.tf
@@ -42,16 +42,16 @@ module "minio" {
   buckets                         = ["one", "two"]
 }
 
-
 resource "vault_generic_secret" "kms_approle" {
   data_json = <<EOT
-{
-"approle_id": "${vault_approle_auth_backend_role.minio_kms.role_id}" ,
-"secret_id": "${vault_approle_auth_backend_role_secret_id.minio_kms.secret_id}"
-}
-EOT
+    {
+      "approle_id": "${vault_approle_auth_backend_role.minio_kms.role_id}" ,
+      "secret_id": "${vault_approle_auth_backend_role_secret_id.minio_kms.secret_id}"
+    }
+  EOT
   path = "secret/kms"
 }
+
 resource "vault_generic_secret" "kms_transit_key" {
   data_json = "{}"
   path = "transit/keys/minio"

--- a/example/minio_standalone/main.tf
+++ b/example/minio_standalone/main.tf
@@ -31,10 +31,12 @@ module "minio" {
                                     }
 
   # Vault transit encryption as KMS
-  use_vault_kms                   = true
-  vault_address                   = "http://10.0.2.15:8200"
-  vault_kms_approle_kv            = vault_generic_secret.kms_approle.path
-  vault_kms_key_name              = "minio"
+  kms_variables                   = {
+                                      use_vault_kms = true,
+                                      vault_address = "http://10.0.2.15:8200",
+                                      vault_kms_approle_kv = vault_generic_secret.kms_approle.path,
+                                      vault_kms_key_name = "minio"
+                                    }
 
   # minio client
   mc_service_name                 = "mc"

--- a/example/minio_standalone/vault_kms.tf
+++ b/example/minio_standalone/vault_kms.tf
@@ -1,0 +1,30 @@
+resource "vault_policy" "minio_kms" {
+  name = "minio_kms"
+  policy = <<EOH
+  path "transit/datakey/plaintext/minio" {
+    capabilities = ["read", "update"]
+  }
+
+  path "transit/decrypt/minio" {
+    capabilities = ["read", "update"]
+  }
+
+  path "transit/rewrap/minio" {
+    capabilities = ["update"]
+  }
+
+  path "transit/keys/minio" {
+    capabilities = ["create", "update", "delete"]
+  }
+EOH
+}
+
+resource "vault_approle_auth_backend_role" "minio_kms" {
+  role_name = "minio_kms"
+  token_policies = [
+    vault_policy.minio_kms.name
+  ]
+}
+resource "vault_approle_auth_backend_role_secret_id" "minio_kms" {
+  role_name = vault_approle_auth_backend_role.minio_kms.role_name
+}

--- a/main.tf
+++ b/main.tf
@@ -49,10 +49,10 @@ data "template_file" "nomad_job_minio" {
     envs                      = local.minio_env_vars
     use_host_volume           = var.use_host_volume
     use_canary                = var.use_canary
-    use_vault_kms             = var.use_vault_kms
-    vault_address             = var.vault_address
-    vault_kms_approle_kv      = var.vault_kms_approle_kv
-    vault_kms_key_name        = var.vault_kms_key_name
+    use_vault_kms             = var.kms_variables.use_vault_kms
+    vault_address             = var.kms_variables.vault_address
+    vault_kms_approle_kv      = var.kms_variables.vault_kms_approle_kv
+    vault_kms_key_name        = var.kms_variables.vault_kms_key_name
     upstreams                 = jsonencode(var.minio_upstreams)
     cpu_proxy                 = var.resource_proxy.cpu
     memory_proxy              = var.resource_proxy.memory

--- a/main.tf
+++ b/main.tf
@@ -49,6 +49,10 @@ data "template_file" "nomad_job_minio" {
     envs                      = local.minio_env_vars
     use_host_volume           = var.use_host_volume
     use_canary                = var.use_canary
+    use_vault_kms             = var.use_vault_kms
+    vault_address             = var.vault_address
+    vault_kms_approle_kv      = var.vault_kms_approle_kv
+    vault_kms_key_name        = var.vault_kms_key_name
     upstreams                 = jsonencode(var.minio_upstreams)
     cpu_proxy                 = var.resource_proxy.cpu
     memory_proxy              = var.resource_proxy.memory

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,21 +1,21 @@
 output "minio_service_name" {
   description = "Minio service name"
-  value       = data.template_file.nomad_job_minio.vars.service_name
+  value       = var.service_name
 }
 
 output "minio_access_key" {
   description = "Minio access key"
-  value       = data.template_file.nomad_job_minio.vars.access_key
+  value       = var.access_key
   sensitive   = true
 }
 
 output "minio_secret_key" {
   description = "Minio secret key"
-  value       = data.template_file.nomad_job_minio.vars.secret_key
+  value       = var.secret_key
   sensitive   = true
 }
 
 output "minio_port" {
   description = "Minio port number"
-  value = data.template_file.nomad_job_minio.vars.port
+  value       = var.port
 }

--- a/variables.tf
+++ b/variables.tf
@@ -167,3 +167,27 @@ variable "mc_extra_commands" {
   default     = [""]
   description = "Extra commands to run in MC container after creating buckets"
 }
+
+# KMS related
+variable "use_vault_kms" {
+  type = bool
+  default = false
+  description = "Use vault transit encryption engine as KMS for transparent encryption (auto-encrypt)"
+}
+
+variable "vault_address" {
+  type = string
+  default = "vault.service.consul:8200"
+  description = "Address to vault service. Only relevant when Vault KMS is used."
+}
+variable "vault_kms_approle_kv" {
+  type = string
+  default = ""
+  description = "Path to key in vault where ApproleID and SecretID is stored. Only relevant when Vault KMS is used."
+}
+
+variable "vault_kms_key_name" {
+  type = string
+  default = ""
+  description = "Name of key in vault transit engine. Only relevant when Vault KMS is used."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -169,25 +169,18 @@ variable "mc_extra_commands" {
 }
 
 # KMS related
-variable "use_vault_kms" {
-  type = bool
-  default = false
-  description = "Use vault transit encryption engine as KMS for transparent encryption (auto-encrypt)"
-}
-
-variable "vault_address" {
-  type = string
-  default = "vault.service.consul:8200"
-  description = "Address to vault service. Only relevant when Vault KMS is used."
-}
-variable "vault_kms_approle_kv" {
-  type = string
-  default = ""
-  description = "Path to key in vault where ApproleID and SecretID is stored. Only relevant when Vault KMS is used."
-}
-
-variable "vault_kms_key_name" {
-  type = string
-  default = ""
-  description = "Name of key in vault transit engine. Only relevant when Vault KMS is used."
+variable "kms_variables" {
+  type = object({
+    use_vault_kms             = string
+    vault_address             = string,
+    vault_kms_approle_kv      = string,
+    vault_kms_key_name        = string
+  })
+  description = "Set of properties to be able to transit secrets in vault"
+  default = {
+    use_vault_kms             = false
+    vault_address             = "",
+    vault_kms_approle_kv      = "",
+    vault_kms_key_name        = ""
+  }
 }


### PR DESCRIPTION
## Closes/fixes/resolves issue(s)?
Closes #113

## What was added/changed/fixed?
- Added Native Vault KMS support using Vault transit encryption #113
  - In this version we are using the deprecated native vault integration.
  - EOL for this feature is October 2021
  - Switch to [MinIO KES](https://github.com/minio/kes/wiki/Hashicorp-Vault-Keystore) before then

## Related issue(s)? [Optional]

## Others [Optional]

## Checklist (after created PR)
- [ ] Added reviewers
- [ ] Added assignee(s)
- [ ] Added label(s)
- [ ] Added to project
- [ ] Added to milestone